### PR TITLE
Delete the first line of setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from importlib.metadata import entry_points
 import setuptools
 
 with open("README.md", "r", encoding="utf-8") as fh:


### PR DESCRIPTION
The first line is useless in this file and it causes this package cannot be installed in Python 3.7 ( maybe Python version < 3.9 )